### PR TITLE
Fix PB handling with game time/real time.

### DIFF
--- a/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
+++ b/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
@@ -61,7 +61,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
         {
             if (SecondaryName != "") return SecondaryName;
 
-            var timeSpan = TargetT[TimingMethod.GameTime];
+            var timeSpan = TargetT[TimingMethod.RealTime];
             if (timeSpan == null) return "Theory ???";
             return $"Theory {formatTimeSpan(timeSpan.Value)}";
         }

--- a/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
+++ b/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
@@ -1,41 +1,38 @@
 ﻿using System;
 using System.Xml;
+using LiveSplit.Model;
 using LiveSplit.UI;
 
 namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 {
     public class ComparisonData
     {
-        public ComparisonData(string split_name, string secondary_name, string target)
+        public ComparisonData(string splitName, string secondaryName, string target)
+            : this(splitName, secondaryName, makeTimeFromString(target))
         {
-            SplitsName = split_name;
-            SecondaryName = secondary_name;
-            Target = target;
+        }
+
+        public ComparisonData(string splitName, string secondaryName, Time target)
+        {
+            SplitsName = splitName;
+            SecondaryName = secondaryName;
+            TargetT = target;
         }
 
         public ComparisonData(ComparisonData other)
         {
             SplitsName = other.SplitsName;
             SecondaryName = other.SecondaryName;
-            Target = other.Target;
+            TargetT = other.TargetT;
         }
 
-        public string Target { get; set; }
-
-        public TimeSpan? TargetT
+        public string Target
         {
-            get
-            {
-                try
-                {
-                    return TimeSpan.Parse(Target);
-                }
-                catch
-                {
-                    return null;
-                }
-            }
+            get => TargetT[TimingMethod.RealTime].ToString();
+            set => TargetT = makeTimeFromString(value);
         }
+
+        public Time TargetT { get; set; }
 
         public string SplitsName { get; set; }
 
@@ -64,9 +61,8 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
         {
             if (SecondaryName != "") return SecondaryName;
 
-            var timeSpan = TargetT;
+            var timeSpan = TargetT[TimingMethod.GameTime];
             if (timeSpan == null) return "Theory ???";
-
             return $"Theory {formatTimeSpan(timeSpan.Value)}";
         }
 
@@ -79,6 +75,19 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
             value = value.TrimStart('0').TrimStart(':');
 
             return value;
+        }
+
+        private static Time makeTimeFromString(string target)
+        {
+            try
+            {
+                var timeSpan = TimeSpan.Parse(target);
+                return new Time(timeSpan, timeSpan);
+            }
+            catch
+            {
+                return Time.Zero;
+            }
         }
     }
 }

--- a/TheoryComparisonGenerator/Comparisons/TheoryPBComparisonGenerator.cs
+++ b/TheoryComparisonGenerator/Comparisons/TheoryPBComparisonGenerator.cs
@@ -21,8 +21,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 
         public override void Generate(ISettings settings)
         {
-            // This is wrong if the game uses different timing method, so we need to dig that out of the state.
-            Data.Target = Run[Run.Count - 1].PersonalBestSplitTime[TimingMethod.RealTime].ToString();
+            Data.TargetT = Run[Run.Count - 1].PersonalBestSplitTime;
             base.Generate(settings);
         }
     }

--- a/TheoryComparisonGenerator/Comparisons/TheoryTimeComparisonGenerator.cs
+++ b/TheoryComparisonGenerator/Comparisons/TheoryTimeComparisonGenerator.cs
@@ -35,7 +35,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 			if (sob == null) return;
 
 			// Target time must also be available.
-			var target = Data.TargetT;
+			var target = Data.TargetT[method];
 			if (target == null) return;
 
 			// Variable multiplier is the amount we need to multiple every gold to get theory split time.

--- a/UI/Components/ComparisonSettings.cs
+++ b/UI/Components/ComparisonSettings.cs
@@ -16,10 +16,6 @@ namespace LiveSplit.UI.Components
     public partial class ComparisonSettings : UserControl
     {
         public ComparisonData Data { get; set; }
-        public string SplitsName { get { return Data.SplitsName; } set { Data.SplitsName = value; } }
-        public string SecondaryName { get { return Data.SecondaryName; } set { Data.SecondaryName = value; } }
-
-        public string Target { get { return Data.Target; } set { Data.Target = value; } }
         protected IList<ComparisonSettings> ComparisonsList { get; set; }
         protected LiveSplitState CurrentState { get; set; }
         protected int ComparisonIndex => ComparisonsList.IndexOf(this);
@@ -73,15 +69,6 @@ namespace LiveSplit.UI.Components
             txtName.Text = Data.SplitsName;
             txtAltName.Text = Data.SecondaryName;
             txtTargetTime.Text = Data.Target;
-
-            // This hooks into data get/set but interferes with the t
-            // txtName.DataBindings.Clear();
-            // txtAltName.DataBindings.Clear();
-            // txtTargetTime.DataBindings.Clear();
-            //
-            // txtName.DataBindings.Add("Text", this, "SplitsName", false, DataSourceUpdateMode.OnPropertyChanged);
-            // txtAltName.DataBindings.Add("Text", this, "SecondaryName", false, DataSourceUpdateMode.OnPropertyChanged);
-            // txtTargetTime.DataBindings.Add("Text", this, "Target", false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
         public void SelectControl()

--- a/UI/Components/TheoryComparisonGeneratorComponent.cs
+++ b/UI/Components/TheoryComparisonGeneratorComponent.cs
@@ -146,11 +146,12 @@ namespace LiveSplit.UI.Components
 
             foreach (var comparisonSetting in Settings.ComparisonsList)
             {
-                // This is a theory time for a different split file.
-                if (comparisonSetting.SplitsName !=
-                    Path.GetFileNameWithoutExtension(CurrentState?.Run.FilePath)) continue;
+                var comparisonData = comparisonSetting.Data;
 
-                var comparison = new TheoryTimeComparisonGenerator(run, comparisonSetting.Data);
+                // This is a theory time for a different split file.
+                if (comparisonData.SplitsName != Path.GetFileNameWithoutExtension(CurrentState?.Run.FilePath)) continue;
+
+                var comparison = new TheoryTimeComparisonGenerator(run, comparisonData);
                 _addComparisonToRun(state, comparison);
             }
 

--- a/UI/Components/TheoryComparisonGeneratorSettings.cs
+++ b/UI/Components/TheoryComparisonGeneratorSettings.cs
@@ -155,7 +155,7 @@ namespace LiveSplit.UI.Components
             var index = 1;
             foreach (var comparison in ComparisonsList)
             {
-                if (comparison.SplitsName == SplitsName || ShowAll)
+                if (comparison.Data.SplitsName == SplitsName || ShowAll)
                 {
                     UpdateLayoutForColumn();
                     AddColumnToLayout(comparison, index);


### PR DESCRIPTION
This change modifies target under ComparisonData to be a Time instance, which we can pass down the PersonalBest to with both correct Real and Game time. Theory time still has both times set to the same, so only one comparison will be accurate, but I would expect that timer would only be showing one at a time.