### PR TITLE
Do not unselect comparison when renaming theory PB

### DIFF
--- a/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
+++ b/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
@@ -38,7 +38,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 
         public string SecondaryName { get; set; }
 
-        public string FormattedName => formatName();
+        public virtual string FormattedName => formatName();
 
         public static ComparisonData FromXml(XmlNode node)
         {
@@ -75,7 +75,10 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
             value = value.TrimStart('0').TrimStart(':');
 
             // Remove suffix which are not needed ".   " becomes "" and .100 becomes ".1"
-            value = value.TrimEnd('0').TrimEnd('.');
+            if (value.IndexOf('.') != -1)
+            {
+                value = value.TrimEnd('0').TrimEnd('.');
+            }
 
             return value;
         }
@@ -91,6 +94,31 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
             {
                 return Time.Zero;
             }
+        }
+    }
+
+    public class PBComparisonData : ComparisonData
+    {
+        public PBComparisonData(bool enabled, string secondaryName)
+            : base("", secondaryName, Time.Zero)
+        {
+            Enabled = enabled;
+        }
+
+        public PBComparisonData(PBComparisonData other)
+            : base(other)
+        {
+            Enabled = other.Enabled;
+        }
+
+        public override string FormattedName => formatName();
+
+        public bool Enabled { get; set; }
+
+        private string formatName()
+        {
+            if (SecondaryName != "") return SecondaryName;
+            return "Theory PB";
         }
     }
 }

--- a/TheoryComparisonGenerator/Comparisons/TheoryPBComparisonGenerator.cs
+++ b/TheoryComparisonGenerator/Comparisons/TheoryPBComparisonGenerator.cs
@@ -6,23 +6,22 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
     public class TheoryPBComparisonGenerator : TheoryTimeComparisonGenerator
     {
 
-        public TheoryPBComparisonGenerator(IRun run, ComparisonData data) : base(run, data)
+        public TheoryPBComparisonGenerator(IRun run, PBComparisonData data) : base(run, data)
         {
-        }
-
-        public override string Name
-        {
-            get
-            {
-                if (Data.SecondaryName != "") return Data.SecondaryName;
-                return "Theory PB";
-            }
+            PBData = data;
         }
 
         public override void Generate(ISettings settings)
         {
             Data.TargetT = Run[Run.Count - 1].PersonalBestSplitTime;
             base.Generate(settings);
+        }
+
+        public PBComparisonData PBData { get; protected set; }
+
+        public override bool ShouldAddToSplits(string splitsName)
+        {
+            return PBData != null && PBData.Enabled;
         }
     }
 }

--- a/TheoryComparisonGenerator/Comparisons/TheoryTimeComparisonGenerator.cs
+++ b/TheoryComparisonGenerator/Comparisons/TheoryTimeComparisonGenerator.cs
@@ -76,5 +76,10 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 				Run[idx].Comparisons[Name] = comparisonTime;
 			}
 		}
+
+		public virtual bool ShouldAddToSplits(string splitsName)
+		{
+			return Data != null && Data.SplitsName == splitsName;
+		}
 	}
 }


### PR DESCRIPTION
This prepares the necessary changes so that renaming the "Theory PB" splits is possible nicely. Missing is the text box UI and hook when text changes. Also TODO: Possibly ban naming it "Personal Best" etc.