### PR TITLE
Move theory times configuration to a secondary file to be loaded in different layouts.

### DIFF
--- a/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
+++ b/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
@@ -75,10 +75,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
             value = value.TrimStart('0').TrimStart(':');
 
             // Remove suffix which are not needed ".   " becomes "" and .100 becomes ".1"
-            if (value.IndexOf('.') != -1)
-            {
-                value = value.TrimEnd('0').TrimEnd('.');
-            }
+            if (value.IndexOf('.') != -1) value = value.TrimEnd('0').TrimEnd('.');
 
             return value;
         }
@@ -87,7 +84,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
         {
             try
             {
-               var timeSpan = TimeSpan.Parse(target);
+                var timeSpan = TimeSpan.Parse(target);
                 return new Time(timeSpan, timeSpan);
             }
             catch
@@ -99,6 +96,8 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 
     public class PBComparisonData : ComparisonData
     {
+        public static PBComparisonData Default = new PBComparisonData(false, "");
+
         public PBComparisonData(bool enabled, string secondaryName)
             : base("", secondaryName, Time.Zero)
         {

--- a/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
+++ b/TheoryComparisonGenerator/Comparisons/ComparisonData.cs
@@ -96,7 +96,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 
     public class PBComparisonData : ComparisonData
     {
-        public static PBComparisonData Default = new PBComparisonData(false, "");
+        public static PBComparisonData Default = new PBComparisonData(true, "");
 
         public PBComparisonData(bool enabled, string secondaryName)
             : base("", secondaryName, Time.Zero)

--- a/UI/Components/TheoryComparisonGeneratorSettings.Designer.cs
+++ b/UI/Components/TheoryComparisonGeneratorSettings.Designer.cs
@@ -31,148 +31,238 @@ namespace LiveSplit.UI.Components
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.groupBoxGeneralSettings = new System.Windows.Forms.GroupBox();
-            this.checkboxAutomaticPBComp = new System.Windows.Forms.CheckBox();
-            this.groupComparisons = new System.Windows.Forms.GroupBox();
-            this.tableComparisons = new System.Windows.Forms.TableLayoutPanel();
-            this.btnAddComparison = new System.Windows.Forms.Button();
-            this.btnShowAll = new System.Windows.Forms.Button();
-            this.txtTheoryPBAltName = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.groupBoxGeneralSettings.SuspendLayout();
-            this.groupComparisons.SuspendLayout();
-            this.tableComparisons.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // tableLayoutPanel1
-            // 
-            this.tableLayoutPanel1.AutoScroll = true;
-            this.tableLayoutPanel1.AutoSize = true;
-            this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.groupBoxGeneralSettings, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.groupComparisons, 0, 1);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(459, 500);
-            this.tableLayoutPanel1.TabIndex = 0;
-            // 
-            // groupBoxGeneralSettings
-            // 
-            this.groupBoxGeneralSettings.Controls.Add(this.label1);
-            this.groupBoxGeneralSettings.Controls.Add(this.txtTheoryPBAltName);
-            this.groupBoxGeneralSettings.Controls.Add(this.checkboxAutomaticPBComp);
-            this.groupBoxGeneralSettings.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxGeneralSettings.Location = new System.Drawing.Point(3, 3);
-            this.groupBoxGeneralSettings.Name = "groupBoxGeneralSettings";
-            this.groupBoxGeneralSettings.Size = new System.Drawing.Size(453, 94);
-            this.groupBoxGeneralSettings.TabIndex = 0;
-            this.groupBoxGeneralSettings.TabStop = false;
-            this.groupBoxGeneralSettings.Text = "General Settings";
-            // 
-            // checkboxAutomaticPBComp
-            // 
-            this.checkboxAutomaticPBComp.Location = new System.Drawing.Point(6, 19);
-            this.checkboxAutomaticPBComp.Name = "checkboxAutomaticPBComp";
-            this.checkboxAutomaticPBComp.Size = new System.Drawing.Size(397, 24);
-            this.checkboxAutomaticPBComp.TabIndex = 0;
-            this.checkboxAutomaticPBComp.Text = "Automatically generate theory comparison for PB";
-            this.checkboxAutomaticPBComp.UseVisualStyleBackColor = true;
-            this.checkboxAutomaticPBComp.CheckedChanged += new System.EventHandler(this.checkboxAutomaticPBComp_CheckedChanged);
-            // 
-            // groupComparisons
-            // 
-            this.groupComparisons.AutoSize = true;
-            this.groupComparisons.Controls.Add(this.tableComparisons);
-            this.groupComparisons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupComparisons.Location = new System.Drawing.Point(3, 103);
-            this.groupComparisons.Name = "groupComparisons";
-            this.groupComparisons.Size = new System.Drawing.Size(453, 394);
-            this.groupComparisons.TabIndex = 1;
-            this.groupComparisons.TabStop = false;
-            this.groupComparisons.Text = "Theory Comparisons";
-            // 
-            // tableComparisons
-            // 
-            this.tableComparisons.AutoScroll = true;
-            this.tableComparisons.AutoSize = true;
-            this.tableComparisons.ColumnCount = 2;
-            this.tableComparisons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 77.85235F));
-            this.tableComparisons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 22.14765F));
-            this.tableComparisons.Controls.Add(this.btnAddComparison, 1, 0);
-            this.tableComparisons.Controls.Add(this.btnShowAll, 0, 0);
-            this.tableComparisons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableComparisons.Location = new System.Drawing.Point(3, 16);
-            this.tableComparisons.Name = "tableComparisons";
-            this.tableComparisons.RowCount = 2;
-            this.tableComparisons.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableComparisons.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableComparisons.Size = new System.Drawing.Size(447, 375);
-            this.tableComparisons.TabIndex = 0;
-            // 
-            // btnAddComparison
-            // 
-            this.btnAddComparison.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnAddComparison.Location = new System.Drawing.Point(369, 3);
-            this.btnAddComparison.Name = "btnAddComparison";
-            this.btnAddComparison.Size = new System.Drawing.Size(75, 23);
-            this.btnAddComparison.TabIndex = 3;
-            this.btnAddComparison.Text = "Add Comparison";
-            this.btnAddComparison.UseVisualStyleBackColor = true;
-            this.btnAddComparison.Click += new System.EventHandler(this.btnAddComparison_Click);
-            // 
-            // btnShowAll
-            // 
-            this.btnShowAll.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnShowAll.Location = new System.Drawing.Point(269, 3);
-            this.btnShowAll.Name = "btnShowAll";
-            this.btnShowAll.Size = new System.Drawing.Size(75, 23);
-            this.btnShowAll.TabIndex = 4;
-            this.btnShowAll.Text = "Show All";
-            this.btnShowAll.UseVisualStyleBackColor = true;
-            this.btnShowAll.Click += new System.EventHandler(this.btnShowAll_Click);
-            // 
-            // txtTheoryPBAltName
-            // 
-            this.txtTheoryPBAltName.Location = new System.Drawing.Point(84, 49);
-            this.txtTheoryPBAltName.Name = "txtTheoryPBAltName";
-            this.txtTheoryPBAltName.Size = new System.Drawing.Size(206, 20);
-            this.txtTheoryPBAltName.TabIndex = 1;
-            this.txtTheoryPBAltName.TextChanged += new System.EventHandler(this.txtTheoryPBAltName_TextChanged);
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 52);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(75, 13);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Display Name:";
-            // 
-            // TheoryComparisonGeneratorSettings
-            // 
-            this.AutoScroll = true;
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.Name = "TheoryComparisonGeneratorSettings";
-            this.Size = new System.Drawing.Size(459, 500);
-            this.Load += new System.EventHandler(this.TheoryComparisonGeneratorSettings_Load);
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            this.groupBoxGeneralSettings.ResumeLayout(false);
-            this.groupBoxGeneralSettings.PerformLayout();
-            this.groupComparisons.ResumeLayout(false);
-            this.groupComparisons.PerformLayout();
-            this.tableComparisons.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+			this.groupBoxGeneralSettings = new System.Windows.Forms.GroupBox();
+			this.label1 = new System.Windows.Forms.Label();
+			this.txtTheoryPBAltName = new System.Windows.Forms.TextBox();
+			this.checkboxAutomaticPBComp = new System.Windows.Forms.CheckBox();
+			this.groupComparisons = new System.Windows.Forms.GroupBox();
+			this.tableComparisons = new System.Windows.Forms.TableLayoutPanel();
+			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+			this.btnAddComparison = new System.Windows.Forms.Button();
+			this.btnShowAll = new System.Windows.Forms.Button();
+			this.tableLayoutPanelFileSelect = new System.Windows.Forms.TableLayoutPanel();
+			this.label2 = new System.Windows.Forms.Label();
+			this.btnBrowse = new System.Windows.Forms.Button();
+			this.txtTheoryTimesPath = new System.Windows.Forms.TextBox();
+			this.btnUnload = new System.Windows.Forms.Button();
+			this.tableLayoutPanel1.SuspendLayout();
+			this.groupBoxGeneralSettings.SuspendLayout();
+			this.groupComparisons.SuspendLayout();
+			this.tableComparisons.SuspendLayout();
+			this.tableLayoutPanel2.SuspendLayout();
+			this.tableLayoutPanelFileSelect.SuspendLayout();
+			this.SuspendLayout();
+			//
+			// tableLayoutPanel1
+			//
+			this.tableLayoutPanel1.AutoScroll = true;
+			this.tableLayoutPanel1.AutoSize = true;
+			this.tableLayoutPanel1.ColumnCount = 1;
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.Controls.Add(this.groupBoxGeneralSettings, 0, 1);
+			this.tableLayoutPanel1.Controls.Add(this.groupComparisons, 0, 2);
+			this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanelFileSelect, 0, 0);
+			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			this.tableLayoutPanel1.RowCount = 3;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 84F));
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(459, 500);
+			this.tableLayoutPanel1.TabIndex = 0;
+			//
+			// groupBoxGeneralSettings
+			//
+			this.groupBoxGeneralSettings.Controls.Add(this.label1);
+			this.groupBoxGeneralSettings.Controls.Add(this.txtTheoryPBAltName);
+			this.groupBoxGeneralSettings.Controls.Add(this.checkboxAutomaticPBComp);
+			this.groupBoxGeneralSettings.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.groupBoxGeneralSettings.Location = new System.Drawing.Point(3, 39);
+			this.groupBoxGeneralSettings.Name = "groupBoxGeneralSettings";
+			this.groupBoxGeneralSettings.Size = new System.Drawing.Size(453, 94);
+			this.groupBoxGeneralSettings.TabIndex = 0;
+			this.groupBoxGeneralSettings.TabStop = false;
+			this.groupBoxGeneralSettings.Text = "General Settings";
+			//
+			// label1
+			//
+			this.label1.AutoSize = true;
+			this.label1.Location = new System.Drawing.Point(3, 52);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(75, 13);
+			this.label1.TabIndex = 2;
+			this.label1.Text = "Display Name:";
+			//
+			// txtTheoryPBAltName
+			//
+			this.txtTheoryPBAltName.Location = new System.Drawing.Point(84, 49);
+			this.txtTheoryPBAltName.Name = "txtTheoryPBAltName";
+			this.txtTheoryPBAltName.Size = new System.Drawing.Size(206, 20);
+			this.txtTheoryPBAltName.TabIndex = 1;
+			this.txtTheoryPBAltName.TextChanged += new System.EventHandler(this.txtTheoryPBAltName_TextChanged);
+			//
+			// checkboxAutomaticPBComp
+			//
+			this.checkboxAutomaticPBComp.Location = new System.Drawing.Point(6, 19);
+			this.checkboxAutomaticPBComp.Name = "checkboxAutomaticPBComp";
+			this.checkboxAutomaticPBComp.Size = new System.Drawing.Size(397, 24);
+			this.checkboxAutomaticPBComp.TabIndex = 0;
+			this.checkboxAutomaticPBComp.Text = "Automatically generate theory comparison for PB";
+			this.checkboxAutomaticPBComp.UseVisualStyleBackColor = true;
+			this.checkboxAutomaticPBComp.CheckedChanged += new System.EventHandler(this.checkboxAutomaticPBComp_CheckedChanged);
+			//
+			// groupComparisons
+			//
+			this.groupComparisons.AutoSize = true;
+			this.groupComparisons.Controls.Add(this.tableComparisons);
+			this.groupComparisons.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.groupComparisons.Location = new System.Drawing.Point(3, 139);
+			this.groupComparisons.Name = "groupComparisons";
+			this.groupComparisons.Size = new System.Drawing.Size(453, 358);
+			this.groupComparisons.TabIndex = 1;
+			this.groupComparisons.TabStop = false;
+			this.groupComparisons.Text = "Theory Comparisons";
+			//
+			// tableComparisons
+			//
+			this.tableComparisons.AutoScroll = true;
+			this.tableComparisons.AutoSize = true;
+			this.tableComparisons.ColumnCount = 1;
+			this.tableComparisons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 77.85235F));
+			this.tableComparisons.Controls.Add(this.tableLayoutPanel2, 0, 0);
+			this.tableComparisons.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableComparisons.Location = new System.Drawing.Point(3, 16);
+			this.tableComparisons.Name = "tableComparisons";
+			this.tableComparisons.RowCount = 2;
+			this.tableComparisons.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10.32448F));
+			this.tableComparisons.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 89.67551F));
+			this.tableComparisons.Size = new System.Drawing.Size(447, 339);
+			this.tableComparisons.TabIndex = 0;
+			//
+			// tableLayoutPanel2
+			//
+			this.tableLayoutPanel2.ColumnCount = 3;
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 82.14286F));
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 17.85714F));
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 55F));
+			this.tableLayoutPanel2.Controls.Add(this.btnAddComparison, 2, 0);
+			this.tableLayoutPanel2.Controls.Add(this.btnShowAll, 1, 0);
+			this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 3);
+			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+			this.tableLayoutPanel2.RowCount = 1;
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+			this.tableLayoutPanel2.Size = new System.Drawing.Size(441, 28);
+			this.tableLayoutPanel2.TabIndex = 5;
+			//
+			// btnAddComparison
+			//
+			this.btnAddComparison.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.btnAddComparison.Location = new System.Drawing.Point(388, 3);
+			this.btnAddComparison.Name = "btnAddComparison";
+			this.btnAddComparison.Size = new System.Drawing.Size(50, 22);
+			this.btnAddComparison.TabIndex = 3;
+			this.btnAddComparison.Text = "Add Comparison";
+			this.btnAddComparison.UseVisualStyleBackColor = true;
+			this.btnAddComparison.Click += new System.EventHandler(this.btnAddComparison_Click);
+			//
+			// btnShowAll
+			//
+			this.btnShowAll.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.btnShowAll.Location = new System.Drawing.Point(320, 3);
+			this.btnShowAll.Name = "btnShowAll";
+			this.btnShowAll.Size = new System.Drawing.Size(62, 22);
+			this.btnShowAll.TabIndex = 4;
+			this.btnShowAll.Text = "Show All";
+			this.btnShowAll.UseVisualStyleBackColor = true;
+			this.btnShowAll.Click += new System.EventHandler(this.btnShowAll_Click);
+			//
+			// tableLayoutPanelFileSelect
+			//
+			this.tableLayoutPanelFileSelect.ColumnCount = 4;
+			this.tableLayoutPanelFileSelect.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+			this.tableLayoutPanelFileSelect.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 275F));
+			this.tableLayoutPanelFileSelect.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 64F));
+			this.tableLayoutPanelFileSelect.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+			this.tableLayoutPanelFileSelect.Controls.Add(this.label2, 0, 0);
+			this.tableLayoutPanelFileSelect.Controls.Add(this.btnBrowse, 2, 0);
+			this.tableLayoutPanelFileSelect.Controls.Add(this.txtTheoryTimesPath, 1, 0);
+			this.tableLayoutPanelFileSelect.Controls.Add(this.btnUnload, 3, 0);
+			this.tableLayoutPanelFileSelect.Location = new System.Drawing.Point(3, 3);
+			this.tableLayoutPanelFileSelect.Name = "tableLayoutPanelFileSelect";
+			this.tableLayoutPanelFileSelect.RowCount = 1;
+			this.tableLayoutPanelFileSelect.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+			this.tableLayoutPanelFileSelect.Size = new System.Drawing.Size(453, 30);
+			this.tableLayoutPanelFileSelect.TabIndex = 2;
+			//
+			// label2
+			//
+			this.label2.Location = new System.Drawing.Point(3, 0);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(52, 26);
+			this.label2.TabIndex = 1;
+			this.label2.Text = "Theory Time File";
+			this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			//
+			// btnBrowse
+			//
+			this.btnBrowse.Location = new System.Drawing.Point(336, 3);
+			this.btnBrowse.Name = "btnBrowse";
+			this.btnBrowse.Size = new System.Drawing.Size(58, 23);
+			this.btnBrowse.TabIndex = 2;
+			this.btnBrowse.Text = "Browse";
+			this.btnBrowse.UseVisualStyleBackColor = true;
+			this.btnBrowse.Click += new System.EventHandler(this.btnBrowse_Click);
+			//
+			// txtTheoryTimesPath
+			//
+			this.txtTheoryTimesPath.Enabled = false;
+			this.txtTheoryTimesPath.Location = new System.Drawing.Point(61, 3);
+			this.txtTheoryTimesPath.Name = "txtTheoryTimesPath";
+			this.txtTheoryTimesPath.Size = new System.Drawing.Size(269, 20);
+			this.txtTheoryTimesPath.TabIndex = 0;
+			//
+			// btnUnload
+			//
+			this.btnUnload.Location = new System.Drawing.Point(400, 3);
+			this.btnUnload.Name = "btnUnload";
+			this.btnUnload.Size = new System.Drawing.Size(50, 23);
+			this.btnUnload.TabIndex = 3;
+			this.btnUnload.Text = "Unload";
+			this.btnUnload.UseVisualStyleBackColor = true;
+			this.btnUnload.Click += new System.EventHandler(this.btnUnload_Click);
+			//
+			// TheoryComparisonGeneratorSettings
+			//
+			this.AutoScroll = true;
+			this.Controls.Add(this.tableLayoutPanel1);
+			this.Name = "TheoryComparisonGeneratorSettings";
+			this.Size = new System.Drawing.Size(459, 500);
+			this.Load += new System.EventHandler(this.TheoryComparisonGeneratorSettings_Load);
+			this.tableLayoutPanel1.ResumeLayout(false);
+			this.tableLayoutPanel1.PerformLayout();
+			this.groupBoxGeneralSettings.ResumeLayout(false);
+			this.groupBoxGeneralSettings.PerformLayout();
+			this.groupComparisons.ResumeLayout(false);
+			this.groupComparisons.PerformLayout();
+			this.tableComparisons.ResumeLayout(false);
+			this.tableLayoutPanel2.ResumeLayout(false);
+			this.tableLayoutPanelFileSelect.ResumeLayout(false);
+			this.tableLayoutPanelFileSelect.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 		}
+
+		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+
+		private System.Windows.Forms.Button btnUnload;
+
+		private System.Windows.Forms.TextBox txtTheoryTimesPath;
+		private System.Windows.Forms.Label label2;
+		private System.Windows.Forms.Button btnBrowse;
+
+		private System.Windows.Forms.TableLayoutPanel tableLayoutPanelFileSelect;
 
 		private System.Windows.Forms.CheckBox checkboxAutomaticPBComp;
 

--- a/UI/Components/TheoryComparisonGeneratorSettings.cs
+++ b/UI/Components/TheoryComparisonGeneratorSettings.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;

--- a/UI/Components/TheoryComparisonGeneratorSettings.cs
+++ b/UI/Components/TheoryComparisonGeneratorSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -12,7 +13,6 @@ namespace LiveSplit.UI.Components
 {
     public partial class TheoryComparisonGeneratorSettings : UserControl
     {
-
         public TheoryComparisonGeneratorSettings(LiveSplitState state)
         {
             InitializeComponent();
@@ -20,11 +20,11 @@ namespace LiveSplit.UI.Components
             CurrentState = state;
             SplitsName = Path.GetFileNameWithoutExtension(CurrentState?.Run.FilePath);
             StartingSize = Size;
-            StartingTableLayoutSize = tableComparisons.Size;
+            StartingTableLayoutSize = tableComparisons.Size + tableLayoutPanel2.Size;
             ComparisonsList = new List<ComparisonSettings>();
             ShowAll = false;
-            TheoryPBData = new PBComparisonData(true, "");
-
+            TheoryPBData = PBComparisonData.Default;
+            TheoryTimesFilePath = null;
         }
 
         public Size StartingSize { get; set; }
@@ -33,13 +33,27 @@ namespace LiveSplit.UI.Components
 
         public PBComparisonData TheoryPBData { get; set; }
 
+        public string TheoryTimesFilePath
+        {
+            get => _theoryTimesFilePath;
+            protected set
+            {
+                txtTheoryTimesPath.Text = _theoryTimesFilePath = value;
+                toggleViewFileLoaded(value);
+            }
+        }
+
+        private string _theoryTimesFilePath { get; set; }
+
+        public FileSystemWatcher TheoryTimesFileWatcher { get; set; }
+
         public string SplitsName { get; set; }
 
         public IList<ComparisonSettings> ComparisonsList { get; set; }
 
+        private bool ShowAll { get; set; }
 
         public event EventHandler OnChange;
-
         public event EventHandler<PBComparisonSettingsChangeEventArgs> OnChangePBComparison;
         public event EventHandler<ComparisonSettingsChangeEventArgs> OnChangeComparison;
 
@@ -47,23 +61,9 @@ namespace LiveSplit.UI.Components
         {
             var element = (XmlElement)node;
 
-            TheoryPBData = new PBComparisonData(TheoryPBData)
-            {
-                Enabled = SettingsHelper.ParseBool(element["AutoTheoryPB"]),
-                SecondaryName = SettingsHelper.ParseString(element["AutoTheoryDisplayName"])
-            };
-
-            var comparisonsElement = element["Comparisons"];
-            ComparisonsList.Clear();
-            foreach (var child in comparisonsElement.ChildNodes)
-            {
-                var comparisonData = ComparisonData.FromXml((XmlNode)child);
-
-                var comparisonControl = new ComparisonSettings(CurrentState, comparisonData.SplitsName, ComparisonsList)
-                { Data = comparisonData };
-                comparisonControl.OnChange += comparisonSettings_OnChange;
-                ComparisonsList.Add(comparisonControl);
-            }
+            var theoryTimesFilePath = SettingsHelper.ParseString(element["TheoryTimesFilePath"]);
+            if (_verifyTheoryTimeFilePathValid(theoryTimesFilePath, true))
+                _updateTheoryTimesFilePath(theoryTimesFilePath);
         }
 
         public XmlNode GetSettings(XmlDocument document)
@@ -80,8 +80,34 @@ namespace LiveSplit.UI.Components
 
         private int CreateSettingsNode(XmlDocument document, XmlElement parent)
         {
+            return SettingsHelper.CreateSetting(document, parent, "TheoryTimesFilePath", TheoryTimesFilePath);
+        }
+
+        private bool _verifyTheoryTimeFilePathValid(string theoryTimeFilePath, bool expectPresent)
+        {
+            if (theoryTimeFilePath == null)
+                return false;
+
+            if (!File.Exists(theoryTimeFilePath))
+                return !expectPresent;
+
+            var theoryTimeFile = File.ReadAllText(theoryTimeFilePath);
+
+            if (theoryTimeFile.Length == 0)
+                return true;
+
+            var document = new XmlDocument();
+            document.LoadXml(theoryTimeFile);
+
+            var elements = document.GetElementsByTagName("TheoryTimesConfig");
+            return elements.Count == 1;
+        }
+
+        private int _createTheoryTimeFileSettings(XmlDocument document, XmlElement parent)
+        {
             var hashCode = SettingsHelper.CreateSetting(document, parent, "AutoTheoryPB", TheoryPBData.Enabled);
-            hashCode ^= SettingsHelper.CreateSetting(document, parent, "AutoTheoryDisplayName", TheoryPBData.SecondaryName);
+            hashCode ^= SettingsHelper.CreateSetting(document, parent, "AutoTheoryDisplayName",
+                TheoryPBData.SecondaryName);
 
             XmlElement comparisonsElement = null;
             if (document != null)
@@ -99,9 +125,11 @@ namespace LiveSplit.UI.Components
                     settings = document.CreateElement("Settings");
                     comparisonsElement.AppendChild(settings);
                 }
+
                 hashCode ^= comparisonData.CreateElement(document, settings) * count;
                 count++;
             }
+
             return hashCode;
         }
 
@@ -115,9 +143,9 @@ namespace LiveSplit.UI.Components
             comparison.MovedDown -= column_MovedDown;
             comparison.MovedUp += column_MovedUp;
             comparison.MovedDown += column_MovedDown;
-
         }
-        void column_MovedDown(object sender, EventArgs e)
+
+        private void column_MovedDown(object sender, EventArgs e)
         {
             var column = (ComparisonSettings)sender;
             var index = ComparisonsList.IndexOf(column);
@@ -125,11 +153,11 @@ namespace LiveSplit.UI.Components
             ComparisonsList.Insert(index + 1, column);
             ResetComparisons();
             column.SelectControl();
+            _writeTheoryTimesFilePath();
             OnChange?.Invoke(this, null);
-
         }
 
-        void column_MovedUp(object sender, EventArgs e)
+        private void column_MovedUp(object sender, EventArgs e)
         {
             var column = (ComparisonSettings)sender;
             var index = ComparisonsList.IndexOf(column);
@@ -137,10 +165,11 @@ namespace LiveSplit.UI.Components
             ComparisonsList.Insert(index - 1, column);
             ResetComparisons();
             column.SelectControl();
+            _writeTheoryTimesFilePath();
             OnChange?.Invoke(this, null);
-
         }
-        void column_ColumnRemoved(object sender, EventArgs e)
+
+        private void column_ColumnRemoved(object sender, EventArgs e)
         {
             var comparison = (ComparisonSettings)sender;
             var index = ComparisonsList.IndexOf(comparison);
@@ -148,6 +177,7 @@ namespace LiveSplit.UI.Components
             ResetComparisons();
             if (ComparisonsList.Count > 0)
                 ComparisonsList.Last().SelectControl();
+            _writeTheoryTimesFilePath();
             OnChange?.Invoke(this, null);
         }
 
@@ -156,7 +186,6 @@ namespace LiveSplit.UI.Components
             ClearLayout();
             var index = 1;
             foreach (var comparison in ComparisonsList)
-            {
                 if (comparison.Data.SplitsName == SplitsName || ShowAll)
                 {
                     UpdateLayoutForColumn();
@@ -164,20 +193,19 @@ namespace LiveSplit.UI.Components
                     comparison.UpdateEnabledButtons();
                     index++;
                 }
-            }
         }
+
         private void ClearLayout()
         {
             tableComparisons.RowCount = 1;
             tableComparisons.RowStyles.Clear();
-            tableComparisons.RowStyles.Add(new RowStyle(SizeType.Absolute, 29f));
+            tableComparisons.RowStyles.Add(new RowStyle(SizeType.Absolute, 34f));
             tableComparisons.Size = StartingTableLayoutSize;
             foreach (var control in tableComparisons.Controls.OfType<ComparisonSettings>().ToList())
-            {
                 tableComparisons.Controls.Remove(control);
-            }
             Size = StartingSize;
         }
+
         private void UpdateLayoutForColumn()
         {
             tableComparisons.RowCount++;
@@ -186,6 +214,7 @@ namespace LiveSplit.UI.Components
             Size = new Size(Size.Width, Size.Height + 179);
             groupComparisons.Size = new Size(groupComparisons.Size.Width, groupComparisons.Size.Height + 179);
         }
+
         private void btnAddComparison_Click(object sender, EventArgs e)
         {
             var comparisonControl = new ComparisonSettings(CurrentState, SplitsName, ComparisonsList);
@@ -194,49 +223,229 @@ namespace LiveSplit.UI.Components
             AddColumnToLayout(comparisonControl, ComparisonsList.Count);
             foreach (var comparison in ComparisonsList)
                 comparison.UpdateEnabledButtons();
+            _writeTheoryTimesFilePath();
             OnChange?.Invoke(this, null);
         }
 
         private void TheoryComparisonGeneratorSettings_Load(object sender, EventArgs e)
         {
             SplitsName = Path.GetFileNameWithoutExtension(CurrentState?.Run.FilePath);
-            checkboxAutomaticPBComp.Checked = TheoryPBData.Enabled;
-            txtTheoryPBAltName.Text = TheoryPBData.SecondaryName;
+            _updateTheoryPBViewFields();
             ResetComparisons();
         }
 
-        private bool ShowAll { get; set; }
         private void btnShowAll_Click(object sender, EventArgs e)
         {
             ShowAll = !ShowAll;
             if (ShowAll)
-            {
                 btnShowAll.Text = "Hide other splits comparisons";
-            }
             else
-            {
                 btnShowAll.Text = "Show All";
-            }
             ResetComparisons();
         }
 
         private void checkboxAutomaticPBComp_CheckedChanged(object sender, EventArgs e)
         {
-            PBComparisonData prevData = TheoryPBData;
+            var prevData = TheoryPBData;
             TheoryPBData = new PBComparisonData(TheoryPBData) { Enabled = checkboxAutomaticPBComp.Checked };
+            _writeTheoryTimesFilePath();
             OnChangePBComparison?.Invoke(this, new PBComparisonSettingsChangeEventArgs(prevData, TheoryPBData));
         }
 
         private void txtTheoryPBAltName_TextChanged(object sender, EventArgs e)
         {
-            PBComparisonData prevData = TheoryPBData;
+            var prevData = TheoryPBData;
             TheoryPBData = new PBComparisonData(TheoryPBData) { SecondaryName = txtTheoryPBAltName.Text };
+            _writeTheoryTimesFilePath();
             OnChangePBComparison?.Invoke(this, new PBComparisonSettingsChangeEventArgs(prevData, TheoryPBData));
         }
 
         private void comparisonSettings_OnChange(object sender, ComparisonSettingsChangeEventArgs e)
         {
+            _writeTheoryTimesFilePath();
             OnChangeComparison?.Invoke(this, e);
+        }
+
+        private void btnBrowse_Click(object sender, EventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Filter = "Live Split Theory Time (*.lstt)|*.lstt|All Files (*.*)|*.*",
+                CheckFileExists = false
+            };
+
+            dialog.FileOk += delegate(object s, CancelEventArgs ev)
+            {
+                if (!_verifyTheoryTimeFilePathValid(dialog.FileName, false))
+                {
+                    MessageBox.Show(
+                        "File does not contain valid theory times, it must either be an empty file or an already valid configuration.",
+                        "Invalid File",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Exclamation
+                    );
+                    ev.Cancel = true;
+                }
+            };
+
+            if (File.Exists(TheoryTimesFilePath))
+            {
+                dialog.InitialDirectory = Path.GetDirectoryName(TheoryTimesFilePath);
+                dialog.FileName = Path.GetFileName(TheoryTimesFilePath);
+            }
+
+            // TODO: add safety to not overwrite random files. Limit to files empty or already .lstt contents?
+
+            if (dialog.ShowDialog() == DialogResult.OK) _updateTheoryTimesFilePath(dialog.FileName);
+        }
+
+        private void _writeTheoryTimesFilePath()
+        {
+            if (TheoryTimesFilePath == null)
+                return;
+
+            var contentsStream = new MemoryStream();
+
+            var document = new XmlDocument();
+
+            XmlNode docNode = document.CreateXmlDeclaration("1.0", "UTF-8", null);
+            document.AppendChild(docNode);
+
+            var parent = document.CreateElement("TheoryTimesConfig");
+            document.AppendChild(parent);
+
+            _createTheoryTimeFileSettings(document, parent);
+
+            document.Save(contentsStream);
+
+            _writeTheoryTimesFileIfChanged(contentsStream.ToString());
+        }
+
+        private void _writeTheoryTimesFileIfChanged(string contents)
+        {
+            var currentContents = File.ReadAllText(TheoryTimesFilePath);
+            if (currentContents != contents)
+                return;
+
+            File.WriteAllText(TheoryTimesFilePath, contents);
+        }
+
+        private void _updateTheoryTimesFilePath(string filePath)
+        {
+            if (TheoryTimesFileWatcher != null)
+            {
+                TheoryTimesFileWatcher.Changed -= _theoryTimesFile_OnChange;
+                TheoryTimesFileWatcher.Renamed -= _theoryTimesFile_OnRenamed;
+            }
+
+            TheoryTimesFilePath = filePath;
+
+            _loadTheoryTimesFilePath(filePath);
+
+            _updateTheoryPBViewFields();
+            ResetComparisons();
+
+            TheoryTimesFileWatcher = new FileSystemWatcher(Path.GetDirectoryName(filePath));
+            TheoryTimesFileWatcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite;
+
+            TheoryTimesFileWatcher.Changed += _theoryTimesFile_OnChange;
+            TheoryTimesFileWatcher.Renamed += _theoryTimesFile_OnRenamed;
+
+            OnChange?.Invoke(this, null);
+        }
+
+        private bool _loadTheoryTimesFilePath(string filePath)
+        {
+            TheoryPBData = PBComparisonData.Default;
+            ComparisonsList.Clear();
+
+            if (!File.Exists(filePath))
+                return false;
+
+            var fileContents = File.ReadAllText(filePath);
+
+            if (fileContents.Length == 0)
+                return true;
+
+            var document = new XmlDocument();
+            document.LoadXml(fileContents);
+
+            var elements = document.GetElementsByTagName("TheoryTimesConfig");
+            if (elements.Count != 1)
+                return false;
+
+            var element = elements[0];
+
+            TheoryPBData = new PBComparisonData(TheoryPBData)
+            {
+                Enabled = SettingsHelper.ParseBool(element["AutoTheoryPB"]),
+                SecondaryName = SettingsHelper.ParseString(element["AutoTheoryDisplayName"])
+            };
+
+            var comparisonsElement = element["Comparisons"];
+            if (comparisonsElement == null)
+                return true;
+
+            foreach (var child in comparisonsElement.ChildNodes)
+            {
+                var comparisonData = ComparisonData.FromXml((XmlNode)child);
+
+                var comparisonControl = new ComparisonSettings(CurrentState, comparisonData.SplitsName, ComparisonsList)
+                    { Data = comparisonData };
+                comparisonControl.OnChange += comparisonSettings_OnChange;
+                ComparisonsList.Add(comparisonControl);
+            }
+
+            return true;
+        }
+
+        private void _updateTheoryPBViewFields()
+        {
+            checkboxAutomaticPBComp.Checked = TheoryPBData.Enabled;
+            txtTheoryPBAltName.Text = TheoryPBData.SecondaryName;
+        }
+
+        private void _theoryTimesFile_OnChange(object sender, FileSystemEventArgs e)
+        {
+            if (e.FullPath != TheoryTimesFilePath)
+                return;
+
+            switch (e.ChangeType)
+            {
+                case WatcherChangeTypes.Changed:
+                    break;
+
+                case WatcherChangeTypes.Renamed:
+                    break;
+            }
+        }
+
+        private void _theoryTimesFile_OnRenamed(object sender, RenamedEventArgs e)
+        {
+            Console.WriteLine("Renamed:");
+            Console.WriteLine($"    Old: {e.OldFullPath}");
+            Console.WriteLine($"    New: {e.FullPath}");
+        }
+
+        private void btnUnload_Click(object sender, EventArgs e)
+        {
+            TheoryTimesFilePath = null;
+            TheoryPBData = PBComparisonData.Default;
+            ComparisonsList.Clear();
+
+            _updateTheoryPBViewFields();
+            ResetComparisons();
+        }
+
+        private void toggleViewFileLoaded(string value)
+        {
+            var hasFileLoaded = value != null;
+
+            btnUnload.Enabled = hasFileLoaded;
+            txtTheoryPBAltName.Enabled = hasFileLoaded;
+            checkboxAutomaticPBComp.Enabled = hasFileLoaded;
+            btnAddComparison.Enabled = hasFileLoaded;
+            btnShowAll.Enabled = hasFileLoaded;
         }
     }
 


### PR DESCRIPTION
This change moves all theory times configuration to a separate secondary file loaded into the layout/component in order to be able to use the same set of times in different livesplit layouts.