### PR TITLE
fix: use simple sum of best calculation

### DIFF
--- a/TheoryComparisonGenerator/Comparisons/TheoryTimeComparisonGenerator.cs
+++ b/TheoryComparisonGenerator/Comparisons/TheoryTimeComparisonGenerator.cs
@@ -31,7 +31,7 @@ namespace LiveSplit.TheoryComparisonGenerator.Comparisons
 			var theorySplitTime = TimeSpan.Zero;
 
 			// For this comparison, we need a full sum of best available to base calculation on.
-			var sob = SumOfBest.CalculateSumOfBest(Run, method: method);
+			var sob = SumOfBest.CalculateSumOfBest(Run, simpleCalculation: true, method: method);
 			if (sob == null) return;
 
 			// Target time must also be available.


### PR DESCRIPTION
Changes the theory time comparison generator to use the simple sum of best calculation, which just sums the stored best times for each segment instead of searching through the whole attempt history.

Games with more dynamic routes can create scenarios where the history-based SoB is faster than the simple calculation. But the split times for the theory comparison are generated as though you used the simple calculation, so you end up with too much time save allocated towards the first N-1 segments. This can leave the last segment with an impossible time.

(This can also happen if you had old attempts with skipped splits and then changed the split order at a later date. Those segments can be removed with the "Clean Sum of Best" function in the split editor, but it's not very intuitive.)